### PR TITLE
Improvement: Removing file extension for custom task

### DIFF
--- a/docs/Configuration_Guide.md
+++ b/docs/Configuration_Guide.md
@@ -6,7 +6,8 @@ The configuration of middleware is performed via command-line arguments, which m
 
 ## Command Line Input Example
 ```
-global_optimization.exe ALG_TYPE:IA TASK_EPS:0.001 CUSTOM_TASK:sphere.txt
+global_optimization.exe ALG_TYPE:GSA CUSTOM_TASK:sphere
+global_optimization.exe ALG_TYPE:IA TASK_NUM:5 TASK_EPS:0.001
 ```
 
 ## Required Keys:
@@ -25,16 +26,17 @@ global_optimization.exe ALG_TYPE:IA TASK_EPS:0.001 CUSTOM_TASK:sphere.txt
 | `SCAN_KEY`| Integer number greater from 1 to 3.<br />Data type: `int` | Scan parameter: key of the scan construction.<br />By default is [DEFAULT_SCAN_KEY](#defined-configuration-constants). |
 | `PRINT_LEVEL`| Integer number from 0 to 2.<br />Data type: `int` | Whether to print points to the file.<br />0 - do not print anything, 1 - print only trial points, 2 - print trial points and functions points.<br />By default is [DEFAULT_PRINT_LEVEL](#defined-configuration-constants). |
 | `ITER_LIMIT`| Integer number greater than 1.<br />Data type: `int` | Limit of iterations of the algorithm to solve the task.<br />By default is [ITERATION_LIMIT](#defined-configuration-constants). |
-| `CUSTOM_TASK`| Name of file with described task (only `.txt` is supported).<br />Data type: `string` | Name of file which consist of task described according to [pattern](#custom-task-pattern).<br />By default is not defined. If defined then `TASK_NUM` key is ignored. |
+| `CUSTOM_TASK`| Name of text file with described task.<br />Data type: `string` | Name of text file which consist of task described according to [pattern](#custom-task-pattern). File extension (must be `.txt`) must not be specified. <br />By default is not defined. If defined then `TASK_NUM` key is ignored. |
 
 # Configuration of GUI
-The configuration of GUI is performed via command-line argument, which is an integer number from 0 to 99. This argument is required.<br />
-Before launching a GUI application for a task with a number `N`, it is necessary to configure and run the middleware for solving this task (pass the `N` value by `TASK_NUM` key). <br />Moreover, if the launch is performed for the first time, it is also necessary to pass the `2` value by the `PRINT_LEVEL` key so that the middleware was generated information for plotting functions.<br />
+The configuration of GUI is performed via command-line argument, which is an integer number from 0 to 99 or string name of text file with custom task. This argument is required.<br />
+Before launching a GUI application for a task with a number or name `X`, it is necessary to configure and run the middleware for solving this task (pass the `X` value by `TASK_NUM` or `CUSTOM_TASK` key). <br />Moreover, if the launch is performed for the first time, it is also necessary to pass the `2` value by the `PRINT_LEVEL` key so that the middleware was generated information for plotting functions.<br />
 Supported only three-dimensional functions.<br />
 
-## Command Line Input Example
+## Command Line Input Examples
 ```
 python graphics_builder.py 5
+python graphics_builder.py sphere
 ```
 
 # Defined Configuration Constants
@@ -52,6 +54,7 @@ python graphics_builder.py 5
 Variable set should consist only lower case Latin letters.<br />
 Mathematical operations should consist only upper case Latin letters.<br />
 Symbols of mathematical operations (for example multiplication) should not be missed.<br />
+Task should be like the following template:<br /> 
 ```
 <variable set> <count of constraints>
 <left task border> <right task border>

--- a/docs/Configuration_Guide.md
+++ b/docs/Configuration_Guide.md
@@ -4,7 +4,7 @@ The configuration of middleware is performed via command-line arguments, which m
 <KEY>:<VALUE>
 ```
 
-## Command Line Input Example
+## Command Line Input Examples
 ```
 global_optimization.exe ALG_TYPE:GSA CUSTOM_TASK:sphere
 global_optimization.exe ALG_TYPE:IA TASK_NUM:5 TASK_EPS:0.001

--- a/docs/Configuration_Guide.md
+++ b/docs/Configuration_Guide.md
@@ -29,8 +29,8 @@ global_optimization.exe ALG_TYPE:IA TASK_NUM:5 TASK_EPS:0.001
 | `CUSTOM_TASK`| Name of text file with described task.<br />Data type: `string` | Name of text file which consist of task described according to [pattern](#custom-task-pattern). File extension (must be `.txt`) must not be specified. <br />By default is not defined. If defined then `TASK_NUM` key is ignored. |
 
 # Configuration of GUI
-The configuration of GUI is performed via command-line argument, which is an integer number from 0 to 99 or string name of text file with custom task. This argument is required.<br />
-Before launching a GUI application for a task with a number or name `X`, it is necessary to configure and run the middleware for solving this task (pass the `X` value by `TASK_NUM` or `CUSTOM_TASK` key). <br />Moreover, if the launch is performed for the first time, it is also necessary to pass the `2` value by the `PRINT_LEVEL` key so that the middleware was generated information for plotting functions.<br />
+The configuration of GUI is performed via command-line argument, which is an `taskId` (integer number from 0 to 99 or string name of text file with custom task). This argument is required.<br />
+Before launching a GUI application for a task with some id `ID`, it is necessary to configure and run the middleware for solving this task (pass the `ID` value by `TASK_NUM` or `CUSTOM_TASK` key). <br />Moreover, if the launch is performed for the first time, it is also necessary to pass the `2` value by the `PRINT_LEVEL` key so that the middleware was generated information for plotting functions.<br />
 Supported only three-dimensional functions.<br />
 
 ## Command Line Input Examples

--- a/docs/Configuration_Guide.md
+++ b/docs/Configuration_Guide.md
@@ -25,7 +25,7 @@ global_optimization.exe ALG_TYPE:IA TASK_EPS:0.001 CUSTOM_TASK:sphere.txt
 | `SCAN_KEY`| Integer number greater from 1 to 3.<br />Data type: `int` | Scan parameter: key of the scan construction.<br />By default is [DEFAULT_SCAN_KEY](#defined-configuration-constants). |
 | `PRINT_LEVEL`| Integer number from 0 to 2.<br />Data type: `int` | Whether to print points to the file.<br />0 - do not print anything, 1 - print only trial points, 2 - print trial points and functions points.<br />By default is [DEFAULT_PRINT_LEVEL](#defined-configuration-constants). |
 | `ITER_LIMIT`| Integer number greater than 1.<br />Data type: `int` | Limit of iterations of the algorithm to solve the task.<br />By default is [ITERATION_LIMIT](#defined-configuration-constants). |
-| `CUSTOM_TASK`| File name with specified extension (only `.txt` is supported).<br />Data type: `string` | File name which contains task described according to [pattern](#custom-task-pattern).<br />By default is not defined. If defined then `TASK_NUM` key is ignored. |
+| `CUSTOM_TASK`| Name of file with described task (only `.txt` is supported).<br />Data type: `string` | Name of file which consist of task described according to [pattern](#custom-task-pattern).<br />By default is not defined. If defined then `TASK_NUM` key is ignored. |
 
 # Configuration of GUI
 The configuration of GUI is performed via command-line argument, which is an integer number from 0 to 99. This argument is required.<br />

--- a/include/algorithm_configurator.hpp
+++ b/include/algorithm_configurator.hpp
@@ -29,7 +29,7 @@
 
 class AlgorithmConfigurator {
     IConstrainedOptProblemFamily* _constrainedProblemFamily;
-    std::map<int, Algorithm*> _algorithmsMap;
+    std::map<std::string, Algorithm*> _algorithmsMap;
     Logger* _logger;
     constants::PrintLevel _printLevel;
 
@@ -43,7 +43,7 @@ class AlgorithmConfigurator {
 
     std::string getPointDescription(Point point, PointType value);
     std::string getCalculationCountDescription(std::vector<long> calculationCounts);
-    void printPointsToFile(int taskNumber, Points points);
+    void printPointsToFile(const std::string& taskId, Points points);
 public:
     AlgorithmConfigurator(int argc, char* argv[], Logger* logger);
     void run();

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -67,4 +67,5 @@ namespace constants {
     const static int GOOD_RETURN_CODE = 0;
     const static int BAD_RETURN_CODE = -1;
     const static long double MIN_ACCURACY = 0.0;
+    const static std::string TXT_FILE_EXTENSION = ".txt";
 }

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -63,7 +63,6 @@ namespace constants {
     const static long double MAX_PEANO_POINT = 1.0;
     const static int DATA_PATHS_COUNT = 3;
     const static long double STEP_PRINT_POINTS = 0.001;
-    const static int CUSTOM_TASK_NUMBER = -1;
     const static int GOOD_RETURN_CODE = 0;
     const static int BAD_RETURN_CODE = -1;
     const static long double MIN_ACCURACY = 0.0;

--- a/include/file_helper.hpp
+++ b/include/file_helper.hpp
@@ -9,7 +9,7 @@
 
 namespace parser {
     std::vector<std::string> parseDirectories(const std::string& pathsFilePath, const std::string& pathsFileName);
-    std::string parseFileName(const std::string& nameContractFilePath, const std::string& nameContractFileName, int taskNumber);
+    std::string parseFileName(const std::string& nameContractFilePath, const std::string& nameContractFileName, const std::string& taskId);
     TemplateTask parseCustomTask(const std::string& configFilePath, const std::string& configFileName, const std::string& customTaskFileName);
 }
 

--- a/src/algorithm_configurator.cpp
+++ b/src/algorithm_configurator.cpp
@@ -55,7 +55,7 @@ AlgorithmConfigurator::AlgorithmConfigurator(int argc, char* argv[], Logger* log
     if (utils::contains(configurationMap, constants::KEY_CUSTOM_TASK)) {
         _algorithmsMap[constants::CUSTOM_TASK_NUMBER] = createAlgorithm(algType,
             parser::parseCustomTask(constants::API_DIR, constants::CONFIG_PATH_FILE,
-                configurationMap[constants::KEY_CUSTOM_TASK]), globalSearchAlgParams, indexAlgParams, scanParams);
+                configurationMap[constants::KEY_CUSTOM_TASK] + constants::TXT_FILE_EXTENSION), globalSearchAlgParams, indexAlgParams, scanParams);
     }
     else {
         _constrainedProblemFamily = new TGrishaginConstrainedProblemFamily();
@@ -109,7 +109,7 @@ Algorithm* AlgorithmConfigurator::createAlgorithm(const std::string& algType,
 
 void AlgorithmConfigurator::run() {
     PointType maxDeviation = -DBL_MAX;
-    for (const auto& [taskNumber, algorithm]: _algorithmsMap) {
+    for (const auto& [taskNumber, algorithm] : _algorithmsMap) {
         _logger->log("CALCULATION OPTIMUM TASK <" + std::to_string(taskNumber) + "> SUCCESSFULLY STARTED.\n");
         _logger->log("EXPECTED OPTIMUM: " +
             getPointDescription(_algorithmsMap[taskNumber]->getTask().getOptimumPoint(),
@@ -125,14 +125,17 @@ void AlgorithmConfigurator::run() {
         else {
             _logger->log("ALGORITHM DID NOT FIND ANY VALID POINTS. TRY INCREASING ACCURACY, RELIABILITY PARAMETER OR SCAN DENSITY.\n");
         }
-        _logger->log("ITERATION COUNT: " + std::to_string(algorithm-> getComplexity().getIterationCount()) + "\n");
-        _logger->log("CALCULATION COUNT: " + 
+        _logger->log("ITERATION COUNT: " + std::to_string(algorithm->getComplexity().getIterationCount()) + "\n");
+        _logger->log("CALCULATION COUNT: " +
             getCalculationCountDescription(algorithm->getComplexity().getFunctionsCalculationCount()) + "\n");
         _logger->log("\n");
 
         printPointsToFile(taskNumber, algorithm->getPoints());
     }
-    _logger->log("MAX DEVIATION AMONG ALL TASKS: " + std::to_string(maxDeviation) + "\n");
+
+    if (!utils::equal(maxDeviation, -DBL_MAX)) {
+        _logger->log("MAX DEVIATION AMONG ALL TASKS: " + std::to_string(maxDeviation) + "\n");
+    }
 }
 
 std::string AlgorithmConfigurator::getPointDescription(Point point, PointType value) {

--- a/src/file_helper.cpp
+++ b/src/file_helper.cpp
@@ -43,7 +43,7 @@ std::vector<std::string> parser::parseDirectories(const std::string& pathsFilePa
 	return paths;
 }
 
-std::string parser::parseFileName(const std::string& nameContractFilePath, const std::string& nameContractFileName, int taskNumber) {
+std::string parser::parseFileName(const std::string& nameContractFilePath, const std::string& nameContractFileName, const std::string& taskId) {
 	std::ifstream nameContractFile(nameContractFilePath + nameContractFileName);
 	if (!nameContractFile.is_open()) {
 		throw ErrorWrapper(Errors::FILE_PARSER_ERROR, "[FILE HELPER] CAN NOT OPEN FILE <" + nameContractFilePath + nameContractFileName + ">.\n");
@@ -57,7 +57,7 @@ std::string parser::parseFileName(const std::string& nameContractFilePath, const
 	if (partsName.size() != 2) {
 		throw ErrorWrapper(Errors::FILE_PARSER_ERROR, "[FILE HELPER] FILE NAME CONSISTS OF <" + std::to_string(partsName.size()) + "> PARTS, <2> IS EXPECTED.\n");
 	}
-	return partsName[0] + std::to_string(taskNumber) + partsName[1];
+	return partsName[0] + taskId + partsName[1];
 }
 
 TemplateTask parser::parseCustomTask(const std::string& configFilePath, const std::string& configFileName, const std::string& customTaskFileName) {


### PR DESCRIPTION
Since the middleware for custom tasks only supports .txt files, there is no need to specify the file extension in the argument. It will also eliminate the need to verify that the received file is indeed a text file (contains the .txt extension).
**Note:** Removed print of maxDeviation if it is not defined.